### PR TITLE
Allow AWS client options overrides for publisher/subscriber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
+## Unreleased
+
+* Adds an option for publisher and subscriber configs to override the AWS client options. *wahlg*
+  See: https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SQS/Client.html
+  See: https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SNS/Client.html
+
 ## Circuitry 3.3.0 (June 23, 2020)
 
 * Update AWS SDK to version 3 and use module sdk gems. *thogg4*
-  See https://github.com/aws/aws-sdk-ruby 
+  See https://github.com/aws/aws-sdk-ruby
   Version 3 is backwards compatible with version 2.
 * Catch `Aws::SNS::Errors::InvalidParameter` and rethrow with the topic
   and message that caused the problem for improved debugging.

--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ Available configuration options for *both* subscriber and publisher applications
 * `middleware`: A chain of middleware that messages must go through when sent or received.
   Please refer to the [Middleware](#middleware) section for more details regarding this
   option.
+* `aws_options_overrides`: A key/value hash of option overrides passed through to the
+   [`AWS::SQS::Client`](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SQS/Client.html)(for subscriber config) or [`AWS::SNS::Client`](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SNS/Client.html)(for publisher config)
 
 Available configuration options for subscriber applications include:
 

--- a/lib/circuitry/config/shared_settings.rb
+++ b/lib/circuitry/config/shared_settings.rb
@@ -15,6 +15,7 @@ module Circuitry
         base.attribute :topic_names, Array[String], default: []
         base.attribute :on_async_exit
         base.attribute :async_strategy, Symbol, default: ->(_page, _att) { :fork }
+        base.attribute :aws_options_overrides, Hash, default: {}
       end
 
       def middleware
@@ -27,7 +28,8 @@ module Circuitry
         {
           access_key_id:     access_key,
           secret_access_key: secret_key,
-          region:            region
+          region:            region,
+          **aws_options_overrides
         }
       end
 

--- a/spec/circuitry/config/publisher_settings_spec.rb
+++ b/spec/circuitry/config/publisher_settings_spec.rb
@@ -25,6 +25,18 @@ RSpec.describe Circuitry::Config::PublisherSettings do
     it 'returns a hash of AWS connection options' do
       expect(subject.aws_options).to eq(access_key_id: 'access_key', secret_access_key: 'secret_key', region: 'region')
     end
+
+    context 'with overrides' do
+      before do
+        subject.aws_options_overrides = {
+          endpoint: 'http://localhost:4566'
+        }
+      end
+
+      it 'includes the overrides in AWS connection options hash' do
+        expect(subject.aws_options).to eq(access_key_id: 'access_key', secret_access_key: 'secret_key', region: 'region', endpoint: 'http://localhost:4566')
+      end
+    end
   end
 
   describe '#middleware' do

--- a/spec/circuitry/config/subscriber_settings_spec.rb
+++ b/spec/circuitry/config/subscriber_settings_spec.rb
@@ -25,6 +25,30 @@ RSpec.describe Circuitry::Config::SubscriberSettings do
     end
   end
 
+  describe '#aws_options' do
+    before do
+      subject.access_key = 'access_key'
+      subject.secret_key = 'secret_key'
+      subject.region = 'region'
+    end
+
+    it 'returns a hash of AWS connection options' do
+      expect(subject.aws_options).to eq(access_key_id: 'access_key', secret_access_key: 'secret_key', region: 'region')
+    end
+
+    context 'with overrides' do
+      before do
+        subject.aws_options_overrides = {
+          endpoint: 'http://localhost:4566'
+        }
+      end
+
+      it 'includes the overrides in AWS connection options hash' do
+        expect(subject.aws_options).to eq(access_key_id: 'access_key', secret_access_key: 'secret_key', region: 'region', endpoint: 'http://localhost:4566')
+      end
+    end
+  end
+
   describe '#middleware' do
     it_behaves_like 'middleware settings'
   end


### PR DESCRIPTION
Adds an option `aws_options_overrides` that accepts a hash of options to merge with the default options passed to the subscriber or publisher clients

Currently, the only settings passed through are [`access_key_id`, `secret_access_key` and `region`](https://github.com/kapost/circuitry/blob/master/lib/circuitry/config/shared_settings.rb#L26-L32)

However, there are many others that it may be useful to override. See:
https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SNS/Client.html
https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SQS/Client.html

For example, the `endpoint` option can enable developers to develop using [`localstack`](https://github.com/localstack/localstack) without needing to connect to real AWS/SNS services.